### PR TITLE
Upgrade Pillow to 7.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Django==2.2.13
 djangorestframework==3.9.2
 idna==2.8
 oauthlib==3.0.1
-Pillow==6.0.0
+Pillow==7.2.0
 pkg-resources==0.0.0
 psycopg2-binary==2.8.1
 PyJWT==1.7.1


### PR DESCRIPTION
7.2.0 is latest version. This will fix #5. See issue for full discussion.

I also recommend looking into https://dependabot.com/python/ for automated dependency updates like this. I notice like Django is outdated by a version; I'm not too familiar with Django to dive in atm. But setting up Dependabot first depends on tests (issue #10) to be implemented to fully confirm that latest functionality is not breaking.